### PR TITLE
Fix /linktree/cinebee 404 in production

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -70,7 +70,7 @@
 
   "rewrites": [
     {
-      "source": "/((?!api|assets|lovable-uploads|sitemap\\.xml|robots\\.txt|llms\\.txt|llms-full\\.txt|favicon\\.ico).*)",
+      "source": "/:path*",
       "destination": "/index.html"
     }
   ]


### PR DESCRIPTION
## Summary
- Replace regex-based SPA catch-all rewrite with Vercel's native `/:path*` wildcard
- The old negative lookahead pattern `((?!api|...).*)` failed to match multi-segment paths like `/linktree/cinebee` in Vercel's routing engine
- Static files (assets, images, favicon, etc.) are already served with priority over rewrites, so the exclusion list was unnecessary

## Root Cause
`/linktree/cinebee` is the only two-segment route in the app. All other routes (`/sterling-petroleum`, `/mathan-electronics`, `/arcspazia`) are single-segment and happened to work fine with the old regex.

## Test plan
- [ ] `/linktree/cinebee` loads correctly in production after deploy
- [ ] Static assets (`/assets/`, `/images/`, `/favicon.ico`) still served correctly
- [ ] All other routes still work

🤖 Generated with [Claude Code](https://claude.com/claude-code)