### PR TITLE
Hotfix: fix SPA routing — all routes 404 in production

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -70,7 +70,7 @@
 
   "rewrites": [
     {
-      "source": "/:path*",
+      "source": "/(.*)",
       "destination": "/index.html"
     }
   ]


### PR DESCRIPTION
## Problem
All client-side routes (`/sterling-petroleum`, `/linktree/cinebee`, etc.) return `x-vercel-error: NOT_FOUND` in production. Only `/` works.

## Root cause
`/:path*` is valid in Vercel **redirects** (it's used correctly in the codexelis.com → www redirect) but does **not** work as a rewrite source. In rewrites, Vercel uses a different path-to-regexp evaluation and `/:path*` fails to match incoming paths.

## Fix
Use Vercel's documented SPA catch-all rewrite pattern `/(.*)"` instead. This is the exact pattern shown in Vercel's SPA routing docs and correctly matches all paths including nested ones like `/linktree/cinebee`.

Static files (assets, images, favicon, sitemap, robots.txt) still take priority over rewrites per Vercel's static file resolution rules — no exclusion list needed.

## Test plan
- [ ] `/` still returns 200
- [ ] `/sterling-petroleum` returns 200 (previously 404)
- [ ] `/linktree/cinebee` returns 200 (the original bug)
- [ ] `/assets/*` and `/images/*` static files still served correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)