### PR TITLE
Hotfix: rewrite destination / fixes all SPA routes

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -71,7 +71,7 @@
   "rewrites": [
     {
       "source": "/(.*)",
-      "destination": "/index.html"
+      "destination": "/"
     }
   ]
 }


### PR DESCRIPTION
## Root cause (confirmed)
`cleanUrls: true` in vercel.json was silently breaking ALL client-side routes.

The rewrite chain for any non-root path was:
1. `/sterling-petroleum` → rewrite to `/index.html`
2. `/index.html` → **308 redirect to `/`** (cleanUrls strips .html)
3. `/` → rewrite fires again → loops → Vercel returns 404

Confirmed by running: `curl -sI https://www.codexelis.com/index.html` → `HTTP/2 308, location: /`

## Fix
Change the rewrite destination from `/index.html` to `/`. Vercel serves `index.html` for `/` as a directory index without triggering `cleanUrls`. Static assets still take priority over the rewrite per Vercel's static file resolution rules.

🤖 Generated with [Claude Code](https://claude.com/claude-code)